### PR TITLE
textNodes inside a design template cause problems in the livingdocs-framework

### DIFF
--- a/lib/build/models/design.coffee
+++ b/lib/build/models/design.coffee
@@ -84,19 +84,16 @@ class Design extends EventEmitter
 
     @debug("Save design.js file to #{javascript_dest}")
     mkdirp path.dirname(javascript_dest), (err) =>
-      if err
-        @emit('error', err)
-        return @emit('end')
+      return @error(err) if err
 
       fs.writeFile javascript_dest, javascript, (err) =>
-        if err
-          @emit('error', err)
-          return @emit('end')
+        return @error(err) if err
 
         @debug('Saved design.js file')
         @debug('Save design.json file')
         fs.writeFile json_dest, json, (err) =>
-          @emit('error', err) if err
+          return @error(err) if err
+
           @debug('Saved design.json file') unless err
           @emit('end')
 
@@ -107,6 +104,11 @@ class Design extends EventEmitter
 
   warn: (err) ->
     @emit('warn', err)
+
+
+  error: (err) ->
+    @emit('error', err)
+    @emit('end')
 
 
 module.exports = Design

--- a/lib/build/models/template.coffee
+++ b/lib/build/models/template.coffee
@@ -1,3 +1,4 @@
+_ = require('lodash')
 cheerio = require("cheerio")
 utils = require("../../utils")
 
@@ -18,8 +19,10 @@ class Template
     config = JSON.parse($(options.configurationElement).html()) || {}
     $(options.configurationElement).remove()
 
+    # filter out comment nodes,
     # check for one root element
-    if $.root().children().length > 1
+    children = _.filter($.root().children(), (el) -> el.nodeType != 8)
+    if children.length > 1
       err = new Error("The Design '#{design.config.name}', Template '#{templateName}' contains more than one root element")
       design.warn(err)
 

--- a/lib/build/models/template.coffee
+++ b/lib/build/models/template.coffee
@@ -22,8 +22,8 @@ class Template
     # filter out comment nodes,
     # check for one root element
     children = _.filter($.root().children(), (el) -> el.nodeType != 8)
-    if children.length > 1
-      err = new Error("The Design '#{design.config.name}', Template '#{templateName}' contains more than one root element")
+    if children.length != 1
+      err = new Error("The Design '#{design.config.name}', Template '#{templateName}' contains #{children.length} root elements. Only 1 is supported.")
       design.warn(err)
 
     html = utils.minifyHtml($.html(), options, @name, design)

--- a/lib/build/models/template.coffee
+++ b/lib/build/models/template.coffee
@@ -13,7 +13,7 @@ class Template
 
 
   @parse: (templateName, templateString, options, design) ->
-    design.debug("parse template '#{templateName}'")
+    design.debug("Parse the template '#{templateName}' of the design '#{design.config.name}'.")
 
     $ = cheerio.load(templateString)
     config = JSON.parse($(options.configurationElement).html()) || {}
@@ -23,12 +23,18 @@ class Template
     # check for one root element
     children = _.filter($.root().contents(), (el) -> el.nodeType == 1)
     if children.length != 1
-      err = new Error("The Design '#{design.config.name}', Template '#{templateName}' contains #{children.length} root elements. Components only work with one root element.")
+      err = new Error("The design '#{design.config.name}', template '#{templateName}' contains #{children.length} root elements. Components only work with one root element.")
       design.warn(err)
 
     outerHtml = $.html(children[0])
-    html = utils.minifyHtml(outerHtml, options, @name, design)
-    design.debug("parsed template '#{templateName}'")
+    try
+      html = utils.minifyHtml(outerHtml, options, templateName)
+    catch err
+      design.warn("Failed to minify the tempate '#{templateName}' of the design '#{design.config.name}'.")
+      design.warn("#{err}")
+      html = ''
+
+    design.debug("Parsed the template '#{templateName}' of the design '#{design.config.name}'.")
     new Template(templateName, html, config)
 
 

--- a/lib/build/models/template.coffee
+++ b/lib/build/models/template.coffee
@@ -19,14 +19,15 @@ class Template
     config = JSON.parse($(options.configurationElement).html()) || {}
     $(options.configurationElement).remove()
 
-    # filter out comment nodes,
+    # filter out comment & text nodes
     # check for one root element
-    children = _.filter($.root().children(), (el) -> el.nodeType != 8)
+    children = _.filter($.root().contents(), (el) -> el.nodeType == 1)
     if children.length != 1
-      err = new Error("The Design '#{design.config.name}', Template '#{templateName}' contains #{children.length} root elements. Only 1 is supported.")
+      err = new Error("The Design '#{design.config.name}', Template '#{templateName}' contains #{children.length} root elements. Components only work with one root element.")
       design.warn(err)
 
-    html = utils.minifyHtml($.html(), options, @name, design)
+    outerHtml = $.html(children[0])
+    html = utils.minifyHtml(outerHtml, options, @name, design)
     design.debug("parsed template '#{templateName}'")
     new Template(templateName, html, config)
 

--- a/lib/utils/index.coffee
+++ b/lib/utils/index.coffee
@@ -6,18 +6,9 @@ exports.filenameToTemplatename = (string) ->
   strings[strings.length - 1]
 
 
-exports.minifyHtml = (html, options, templateName, ee) ->
+exports.minifyHtml = (html, options) ->
   if options?.minify
-    try
-      htmlmin.minify(html, options.minify)
-    catch err
-      warning = ">> Template '#{templateName}': HTML minify error\n #{err}\n"
-      if ee
-        ee.emit('warn', warning)
-      else
-        console.warn(warning)
-
-      return '<div class="error minify" style="color: red">Error while minifying: Template "#{templateName}"</div>'
+    htmlmin.minify(html, options.minify)
 
   else
     html.trim()


### PR DESCRIPTION
This pull request changes the template parsing and filters comments and textnodes out of the design templates.
