### PR TITLE
use slice instead of splice when getting cli arguments

### DIFF
--- a/bin/commands.coffee
+++ b/bin/commands.coffee
@@ -262,7 +262,7 @@ authenticate = (callback) ->
 
 
 authenticateProject = (callback) ->
-  c = minimist process.argv.splice(3),
+  c = minimist process.argv.slice(3),
     string: ['project', 'name', 'version']
     alias:
       s: 'project'


### PR DESCRIPTION
Fixes Issue https://github.com/upfrontIO/livingdocs-manager/issues/22
