### PR TITLE
feat(channel): add handling of channel endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,22 +18,23 @@ Usage: ldm <command>
 
 where: <command> is one of:
 
-  help                          #  Show this information
+  help                              #  Show this information
 
-  version                       #  Show the cli version
+  version                           #  Show the cli version
 
-  user:info                     #  Prints the user information
+  user:info                         #  Prints the user information
 
-  design:build                  #  Compile the design
-  design:publish                #  Show the script version
-  design:proxy                  #  Start a design server that caches designs
+  design:build                      #  Compile the design
+  design:publish                    #  Show the script version
+  design:proxy                      #  Start a design server that caches designs
 
-  project:design:list           #  List all designs of a project
-  project:design:add            #  Add a design to a project
-  project:design:remove         #  Remove a design from a project
-  project:design:default        #  Set a design as default
-  project:design:enable         #  Enable project's design
-  project:design:disable        #  Disable project's design
+  project:channel:list              #  List all designs of all channels of a project
+
+  channel:design-version:add        #  Add a design version to a channel
+  channel:design-version:remove     #  Remove a design version from a channel
+  channel:design-version:current    #  Set a current design version as default of a channel
+  channel:design-version:enable     #  Enable a design version of a channel
+  channel:design-version:disable    #  Disable a design version of a channel
 ```
 
 

--- a/lib/api/index.coffee
+++ b/lib/api/index.coffee
@@ -67,7 +67,7 @@ module.exports = api =
           username: options.username
           password: '[redacted]'
 
-        callback(api.requestError(res, body, "Authentication failed"))
+        callback(api.requestError(res, body, 'Authentication failed'))
 
       else
         callback null,
@@ -135,57 +135,58 @@ api.project =
       log.verbose('api:project:get', api.requestError(res))
       callback(null, body.project)
 
+
   listDesigns: (options, projectId, callback) ->
     @get options, projectId, (err, project) ->
       return callback(err) if err
       callback null,
-        defaultDesign: project.default_design
-        designs: project.designs
+        channels: project.channels
+        defaultChannel: project.default_channel
 
 
-  addDesign: (options, {projectId, design} = {}, callback) ->
-    assertDesign(design)
-    postAction('add-design', {projectId, design}, options, callback)
+  addDesignVersion: (options, {channelId, designVersion} = {}, callback) ->
+    assertDesignVersion(designVersion)
+    channelPostAction('add-design-version', {channelId, designVersion}, options, callback)
 
 
-  disableDesign: (options, {projectId, design} = {}, callback) ->
-    assertDesign(design)
-    postAction('disable-design', {projectId, design}, options, callback)
+  disableDesignVersion: (options, {channelId, designVersion} = {}, callback) ->
+    assertDesignVersion(designVersion)
+    channelPostAction('disable-design-version', {channelId, designVersion}, options, callback)
 
 
-  enableDesign: (options, {projectId, design} = {}, callback) ->
-    assertDesign(design)
-    postAction('enable-design', {projectId, design}, options, callback)
+  enableDesignVersion: (options, {channelId, designVersion} = {}, callback) ->
+    assertDesignVersion(designVersion)
+    channelPostAction('enable-design-version', {channelId, designVersion}, options, callback)
 
 
-  removeDesign: (options, {projectId, design} = {}, callback) ->
-    assertDesign(design)
-    postAction('remove-design', {projectId, design}, options, callback)
+  removeDesignVersion: (options, {channelId, designVersion} = {}, callback) ->
+    assertDesignVersion(designVersion)
+    channelPostAction('remove-design-version', {channelId, designVersion}, options, callback)
 
 
-  setDefaultDesign: (options, {projectId, design} = {}, callback) ->
-    assertDesign(design)
-    postAction('set-default-design', {projectId, design}, options, callback)
+  setCurrentDesignVersion: (options, {channelId, designVersion} = {}, callback) ->
+    assertDesignVersion(designVersion)
+    channelPostAction('set-current-design-version', {channelId, designVersion}, options, callback)
 
 
-postAction = (action, {projectId, design}, options, callback) ->
+channelPostAction = (action, {channelId, designVersion}, options, callback) ->
   request
     method: 'post'
-    url: "#{options.host}/projects/#{projectId}/#{action}",
+    url: "#{options.host}/channels/#{channelId}/#{action}",
     headers: Authorization: "Bearer #{options.token}"
-    body: design
+    body:
+      design_version: designVersion
     json: true
   , (err, res, body) ->
     if res?.statusCode == 204
       return callback(null)
 
-    log.verbose("api:project:#{action}", api.requestError(res))
+    log.verbose("api:channels:#{action}", api.requestError(res))
     if err
       return callback(err)
     else
-      callback(api.requestError(res, null, "Unhandled error"))
+      callback(api.requestError(res, null, 'Unhandled error'))
 
 
-assertDesign = (design) ->
-  assert(design.name, 'design.name is required')
-  assert(_.isString(design.version), 'design.version is required')
+assertDesignVersion = (designVersion) ->
+  assert(_.isString(designVersion), 'designVersion is required')

--- a/lib/print/index.coffee
+++ b/lib/print/index.coffee
@@ -22,12 +22,15 @@ print.each = (arr, method) ->
   print
 
 
-print.design = (design) ->
-  identifier = "#{design?.name}@#{design?.version}"
-  postfix = ''
-  postfix += ' - not selectable' if design.is_selectable == false
-  postfix += ' - disabled' if design.is_disabled == true
-  console.log(identifier + postfix)
+print.channel = (channel) ->
+  print
+    .line "#{channel.name}"
+    .line '  channel id', channel.id
+    .line '  design name', channel.design_name
+    .line '  current version', channel.current_version
+    .line '  available versions', channel.available_versions.toString()
+    .line '  disabled versions', channel.disabled_versions.toString()
+    .line ''
   print
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livingdocs-manager",
-  "version": "2.4.4",
+  "version": "3.0.0",
   "description": "A cli to manage designs and the configuration of a livingdocs server.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Since we decided to introduce channels on the livingdocs-server project, we need to support this channels on the livingdocs-manager project.

**BREAKING CHANGE**
- remove command project:design:list
- remove command project:design:add
- remove command project:design:remove
- remove command project:design:default
- remove command project:design:enable
- remove command project:design:disable
- add command channel:design-version:add
- add command channel:design-version:remove
- add command channel:design-version:current
- add command channel:design-version:enable
- add command channel:design-version:disable

**Attention!** This PR can only be merged, when livingdocs-server is completely migrated to the channel feature.
