### PR TITLE
fix(design-list): prevent crashing of the project:design:list command

### DIFF
--- a/bin/commands.coffee
+++ b/bin/commands.coffee
@@ -193,7 +193,7 @@ commands =
           return log.error('project:design:list', err) if err
           print
             .topic('Default Channel Name')
-            .line(defaultChannel.name)()
+            .line(defaultChannel?.name)()
           print
             .topic('Channels')
             .each(channels, print.channel)()


### PR DESCRIPTION
With this fix, `project:design:list` doesn't crash, when there is no defaultChannel.
