### PR TITLE
Fix: Update html minifier to fix svg closing tag bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "express": "^4.13.1",
     "glob": "^4.3.5",
     "gunzip-maybe": "^1.2.1",
-    "html-minifier": "^0.6.9",
+    "html-minifier": "^3.5.21",
     "inquirer": "^0.8.0",
     "lodash": "^3.10.0",
     "mime": "^1.3.4",


### PR DESCRIPTION
## Changelog

Update `html-minifier` to the latest version to fix a bug where self-closing tags insidve of SVG elements would be removed.