### PR TITLE
fix: migrate auth endpoint

### DIFF
--- a/lib/api/index.coffee
+++ b/lib/api/index.coffee
@@ -45,7 +45,7 @@ module.exports = api =
 
     request
       method: 'post'
-      url: options.host+'/authenticate'
+      url: options.host+'/auth/local/login'
       body:
         username: options.user
         password: options.password


### PR DESCRIPTION
# Motivation
Integrates latest breaking changes from the `livingdocs-server@release-2020-12`