### PR TITLE
fix: introduce cookie support and migrate auth routes

### DIFF
--- a/lib/api/index.coffee
+++ b/lib/api/index.coffee
@@ -45,7 +45,7 @@ module.exports = api =
 
     request
       method: 'post'
-      url: options.host+'/authenticate'
+      url: options.host+'/auth/local/login'
       body:
         username: options.user
         password: options.password

--- a/lib/request.coffee
+++ b/lib/request.coffee
@@ -1,4 +1,4 @@
-request = require('request')
+request = require('request').defaults({jar: true})
 _ = require('lodash')
 parseWarningHeader = require('warning-header-parser')
 log = require('npmlog')


### PR DESCRIPTION
BREAKING CHANGE:
🔥 migrate livingdocs authentication routes from `'/authenticate'` to `'/auth/local/login'`